### PR TITLE
Split test environment into separate wp-env config

### DIFF
--- a/.github/workflows/run-test-and-deploy.yml
+++ b/.github/workflows/run-test-and-deploy.yml
@@ -60,9 +60,9 @@ jobs:
 
       - name: Install WordPress
         run: |
-          WP_ENV_CORE=WordPress/${{ matrix.wp }} WP_ENV_PHP_VERSION=${{ matrix.php }} npm run wp-env start
-          npm run wp-env run cli wp core version
-          npm run wp-env run cli wp cli info
+          WP_ENV_CORE=WordPress/${{ matrix.wp }} WP_ENV_PHP_VERSION=${{ matrix.php }} npm run wp-env-test start
+          npm run wp-env-test run cli wp core version
+          npm run wp-env-test run cli wp cli info
 
       - name: Running e2e tests
         run: npm run test:e2e

--- a/.github/workflows/run-test.yml
+++ b/.github/workflows/run-test.yml
@@ -68,9 +68,9 @@ jobs:
 
       - name: Install WordPress
         run: |
-          WP_ENV_CORE=WordPress/${{ matrix.wp }} WP_ENV_PHP_VERSION=${{ matrix.php }} npm run wp-env start
-          npm run wp-env run cli wp core version
-          npm run wp-env run cli wp cli info
+          WP_ENV_CORE=WordPress/${{ matrix.wp }} WP_ENV_PHP_VERSION=${{ matrix.php }} npm run wp-env-test start
+          npm run wp-env-test run cli wp core version
+          npm run wp-env-test run cli wp cli info
 
       - name: Running e2e tests
         run: npm run test:e2e

--- a/.wp-env.test.json
+++ b/.wp-env.test.json
@@ -5,5 +5,10 @@
 		"https://downloads.wordpress.org/plugin/wp-downgrade.zip"
 	],
 	"testsEnvironment": false,
-	"phpmyadminPort": 9000
+	"port": 8889,
+	"phpmyadminPort": 9001,
+	"config": {
+		"WP_DEBUG": true,
+		"SCRIPT_DEBUG": true
+	}
 }

--- a/package.json
+++ b/package.json
@@ -34,7 +34,8 @@
 	},
 	"scripts": {
 		"wp-env": "wp-env",
-		"stop": "wp-env stop",
+		"wp-env-test": "wp-env --config .wp-env.test.json",
+		"stop": "wp-env stop && wp-env --config .wp-env.test.json stop",
 		"start": "wp-scripts start",
 		"build": "wp-scripts build",
 		"check-licenses": "wp-scripts check-licenses",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -6,4 +6,8 @@ const config = require( '@wordpress/scripts/config/playwright.config.js' );
 export default {
 	...config,
 	testDir: './test/e2e',
+	webServer: {
+		...config.webServer,
+		command: 'npm run wp-env-test -- start',
+	},
 };


### PR DESCRIPTION
wp-env deprecated starting both development and tests environments by default, along with the env/testsPort/testsEnvironment options. Move the tests environment into a dedicated .wp-env.test.json loaded via --config, and set testsEnvironment to false so only the development environment starts by default and the deprecation warning is silenced.

Add a wp-env-test script and override the Playwright webServer command so e2e tests boot the test config on port 8889, and update CI to start the test environment the same way.