### PR TITLE
Fix stored XSS by using validated media type in source tag

### DIFF
--- a/enable-responsive-image.php
+++ b/enable-responsive-image.php
@@ -99,7 +99,7 @@ function enable_responsive_image_render_block_image( $block_content, $block ) {
 		$source_tags .= sprintf(
 			'<source srcset="%1$s" media="(%2$s: %3$dpx)"/>',
 			esc_url( $source['srcset'] ),
-			$source['mediaType'],
+			$media_type,
 			$source['mediaValue'] ? (int) $source['mediaValue'] : $default_media_value,
 		);
 	}


### PR DESCRIPTION
The media attribute was built from the raw mediaType block attribute instead of the whitelist-validated $media_type, letting attacker-set block attributes break out of the HTML attribute context. Output the validated value so only min-width/max-width can be emitted.