### PR TITLE
Improve TypeScript coverage

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -37,10 +37,13 @@ module.exports = [
 			],
 		},
 	},
-	{
-		files: [ 'test/**' ],
+	...defaultConfig.configs[ 'test-e2e' ].map( ( config ) => ( {
+		...config,
+		files: [ 'test/e2e/**/*.ts' ],
 		rules: {
+			...config.rules,
+			'jest/expect-expect': 'off',
 			'react-hooks/rules-of-hooks': 'off',
 		},
-	},
+	} ) ),
 ];

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
 				"@types/wordpress__block-editor": "15.0.6",
 				"@wordpress/base-styles": "10.0.1",
 				"@wordpress/core-data": "7.48.1",
+				"@wordpress/e2e-test-utils-playwright": "1.48.1",
 				"@wordpress/env": "^11.8.1",
 				"@wordpress/icons": "14.0.1",
 				"@wordpress/scripts": "^32.4.1",

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
 		"@types/wordpress__block-editor": "15.0.6",
 		"@wordpress/base-styles": "10.0.1",
 		"@wordpress/core-data": "7.48.1",
+		"@wordpress/e2e-test-utils-playwright": "1.48.1",
 		"@wordpress/env": "^11.8.1",
 		"@wordpress/icons": "14.0.1",
 		"@wordpress/scripts": "^32.4.1",

--- a/playwright.config.js
+++ b/playwright.config.js
@@ -3,7 +3,7 @@
  */
 const config = require( '@wordpress/scripts/config/playwright.config.js' );
 
-export default {
+module.exports = {
 	...config,
 	testDir: './test/e2e',
 	webServer: {

--- a/test/e2e/test.spec.ts
+++ b/test/e2e/test.spec.ts
@@ -1,7 +1,8 @@
+/// <reference types="node" />
 /**
  * External dependencies
  */
-import type { Page } from '@playwright/test';
+import type { Locator, Page } from '@playwright/test';
 import path from 'path';
 import fs from 'fs';
 import os from 'os';
@@ -11,6 +12,11 @@ import { v4 as uuid } from 'uuid';
  * WordPress dependencies
  */
 import { test as base, expect } from '@wordpress/e2e-test-utils-playwright';
+
+/**
+ * Internal dependencies
+ */
+import type { Source } from '../../src/types';
 
 const test = base.extend< {
 	mediaUtils: MediaUtils;
@@ -102,9 +108,9 @@ test.describe( 'Image Block', () => {
 			},
 		] );
 
-		const sources = blocks[ 0 ].attributes.enableResponsiveImageSources;
-		expect( sources?.[ 0 ].srcset.includes( firstSourceFilename ) ).toBe( true );
-		expect( sources?.[ 1 ].srcset.includes( secondSourceFilename ) ).toBe( true );
+		const sources = blocks[ 0 ].attributes.enableResponsiveImageSources as Source[];
+		expect( sources?.[ 0 ]?.srcset?.includes( firstSourceFilename ) ).toBe( true );
+		expect( sources?.[ 1 ]?.srcset?.includes( secondSourceFilename ) ).toBe( true );
 	} );
 } );
 
@@ -112,12 +118,12 @@ class MediaUtils {
 	page: Page;
 	basePath: string;
 
-	constructor( { page } ) {
+	constructor( { page }: { page: Page } ) {
 		this.page = page;
 		this.basePath = path.join( __dirname, 'assets' );
 	}
 
-	async uploadImage( inputElement, customFile ) {
+	async uploadImage( inputElement: Locator, customFile: string ) {
 		const tmpDirectory = await fs.mkdtempSync( path.join( os.tmpdir(), 'test-image-' ) );
 		const filename = uuid();
 		const tmpFileName = path.join( tmpDirectory, filename + '.png' );
@@ -127,7 +133,7 @@ class MediaUtils {
 		return filename;
 	}
 
-	async uploadSource( customFile ) {
+	async uploadSource( customFile: string ) {
 		const filename = await this.uploadImage(
 			this.page.locator( '.media-modal .moxie-shim input[type=file]' ),
 			customFile
@@ -139,7 +145,7 @@ class MediaUtils {
 		return filename;
 	}
 
-	async changeMediaQueryType( option, index = 0 ) {
+	async changeMediaQueryType( option: string, index = 0 ) {
 		const blockSettings = this.page.getByRole( 'region', {
 			name: 'Editor settings',
 		} );
@@ -150,7 +156,7 @@ class MediaUtils {
 			.setChecked( true );
 	}
 
-	async changeMediaQueryValue( value, index = 0 ) {
+	async changeMediaQueryValue( value: string, index = 0 ) {
 		const blockSettings = this.page.getByRole( 'region', {
 			name: 'Editor settings',
 		} );
@@ -160,7 +166,7 @@ class MediaUtils {
 			.fill( value );
 	}
 
-	async changeResolution( option, index = 0 ) {
+	async changeResolution( option: string, index = 0 ) {
 		const blockSettings = this.page.getByRole( 'region', {
 			name: 'Editor settings',
 		} );

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -10,6 +10,6 @@
 		"resolveJsonModule": true,
 		"skipLibCheck": true
 	},
-	"include": [ "src/**/*", "src/**/*.json" ],
+	"include": [ "src/**/*", "src/**/*.json", "test/**/*" ],
 	"exclude": [ "**/build/**" ]
 }


### PR DESCRIPTION
## What

Improves TypeScript coverage, mirroring t-hamano/piano-block#128 for this plugin's architecture.

- Add `test/**/*` to the `tsconfig.json` `include` so e2e tests are type-checked.
- Declare `@wordpress/e2e-test-utils-playwright` explicitly (it was used in the e2e test but only present transitively).
- Convert `playwright.config.ts` → `playwright.config.js` (CommonJS), matching its `require()`-based usage.
- Type the e2e test: `MediaUtils` method params, `Locator`/`Page` imports, and cast the source attribute to `Source[]`. Add a `/// <reference types="node" />` so `path`/`fs`/`os`/`__dirname` resolve (kept scoped to the test file instead of a global `tsconfig` `types` setting).
- Apply the `test-e2e` ESLint config to e2e specs, disabling `jest/expect-expect` and `react-hooks/rules-of-hooks`.

## Notes

Unlike piano-block, this plugin extends `core/image` via `addFilter` rather than registering its own block, so the `registerBlockType`/`BlockConfiguration` and `index.d.ts → globals.d.ts` parts of that PR don't apply here. `src/scss.d.ts` already exists.

`@types/node` is not declared explicitly because `@wordpress/e2e-test-utils-playwright` depends on it directly.

## Testing

- `npm run lint:types` passes
- `npm run lint:js` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)