### PR TITLE
Drop support for WordPress 6.9

### DIFF
--- a/.github/workflows/run-test-and-deploy.yml
+++ b/.github/workflows/run-test-and-deploy.yml
@@ -14,22 +14,22 @@ jobs:
           - php: '8.0'
             wp: WordPress
           - php: '8.0'
-            wp: WordPress#6.9.1
+            wp: WordPress#7.0
 
           - php: '8.2'
             wp: WordPress
           - php: '8.2'
-            wp: WordPress#6.9.1
+            wp: WordPress#7.0
 
           - php: '8.4'
             wp: WordPress
           - php: '8.4'
-            wp: WordPress#6.9.1
+            wp: WordPress#7.0
 
           - php: '8.5'
             wp: WordPress
           - php: '8.5'
-            wp: WordPress#6.9.1
+            wp: WordPress#7.0
 
     name: PHP ${{ matrix.php }} / ${{ matrix.wp }} Test
 

--- a/.github/workflows/run-test.yml
+++ b/.github/workflows/run-test.yml
@@ -22,22 +22,22 @@ jobs:
           - php: '8.0'
             wp: WordPress
           - php: '8.0'
-            wp: WordPress#6.9.1
+            wp: WordPress#7.0
 
           - php: '8.2'
             wp: WordPress
           - php: '8.2'
-            wp: WordPress#6.9.1
+            wp: WordPress#7.0
 
           - php: '8.4'
             wp: WordPress
           - php: '8.4'
-            wp: WordPress#6.9.1
+            wp: WordPress#7.0
 
           - php: '8.5'
             wp: WordPress
           - php: '8.5'
-            wp: WordPress#6.9.1
+            wp: WordPress#7.0
 
     name: PHP ${{ matrix.php }} / ${{ matrix.wp }} Test
 

--- a/enable-responsive-image.php
+++ b/enable-responsive-image.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name: Enable Responsive Image
  * Description: Adds settings to the Image block to display different images depending on the width of the screen.
- * Requires at least: 6.9
+ * Requires at least: 7.0
  * Requires PHP: 8.0
  * Version: 1.6.1
  * Author: Aki Hamano

--- a/readme.txt
+++ b/readme.txt
@@ -1,7 +1,7 @@
 === Enable Responsive Image ===
 Contributors: wildworks, Toro_Unit
 Tags: gutenberg, block, image, responsive
-Requires at least: 6.9
+Requires at least: 7.0
 Tested up to: 7.0
 Stable tag: 1.6.1
 Requires PHP: 8.0

--- a/test/e2e/test.spec.ts
+++ b/test/e2e/test.spec.ts
@@ -36,8 +36,6 @@ test.describe( 'Image Block', () => {
 	} );
 
 	test( 'should create image with image sources', async ( { editor, page, mediaUtils } ) => {
-		const wpVersion = await mediaUtils.getWpVersion();
-
 		// Insert Image block.
 		await editor.insertBlock( { name: 'core/image' } );
 		const imageBlock = editor.canvas.getByRole( 'document', {
@@ -58,9 +56,7 @@ test.describe( 'Image Block', () => {
 
 		// Add first image source.
 		await editor.openDocumentSettingsSidebar();
-		if ( wpVersion !== '6.9' ) {
-			await page.getByRole( 'tab', { name: 'Settings' } ).click();
-		}
+		await page.getByRole( 'tab', { name: 'Settings' } ).click();
 		await page.getByRole( 'button', { name: 'Add image source' } ).click();
 		await page.getByRole( 'button', { name: 'Set image source' } ).click();
 		const firstSourceFilename = await mediaUtils.uploadSource( '600x450.png' );
@@ -177,15 +173,5 @@ class MediaUtils {
 			.selectOption( {
 				label: option,
 			} );
-	}
-
-	async getWpVersion() {
-		const body = await this.page.$( 'body' );
-		if ( ! body ) {
-			throw new Error( 'Could not find body element' );
-		}
-		const bodyClassNames = await ( await body.getProperty( 'className' ) ).jsonValue();
-		const matches = bodyClassNames.match( /branch-([0-9]*-*[0-9])/ );
-		return matches?.[ 1 ];
 	}
 }


### PR DESCRIPTION
Raise the minimum required WordPress version to 7.0 so the plugin can rely on 7.0 editor behavior without runtime branching. Remove the e2e fallback that handled the 6.9 sidebar layout and the now-unused getWpVersion helper, and update the CI matrix to test against 7.0.