### PR TITLE
Improve accessibility of image source mover buttons

### DIFF
--- a/src/source-editor.tsx
+++ b/src/source-editor.tsx
@@ -2,7 +2,7 @@
  * WordPress dependencies
  */
 import { useState } from '@wordpress/element';
-import { __ } from '@wordpress/i18n';
+import { __, sprintf } from '@wordpress/i18n';
 import {
 	Button,
 	DropZone,
@@ -12,7 +12,8 @@ import {
 	__experimentalToggleGroupControl as ToggleGroupControl,
 	__experimentalToggleGroupControlOption as ToggleGroupControlOption,
 } from '@wordpress/components';
-import { Stack, Link } from '@wordpress/ui';
+import { Stack, Link, VisuallyHidden } from '@wordpress/ui';
+import { useInstanceId } from '@wordpress/compose';
 import { MediaUpload, store as blockEditorStore } from '@wordpress/block-editor';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { store as coreStore } from '@wordpress/core-data';
@@ -28,6 +29,7 @@ import { DEFAULT_MEDIA_VALUE, MEDIA_TYPES, MIN_MEDIA_VALUE, MAX_MEDIA_VALUE } fr
 
 type Props = {
 	source?: Source;
+	index?: number;
 	disableMoveUp: boolean;
 	disableMoveDown: boolean;
 	disableActions?: boolean;
@@ -45,6 +47,7 @@ export default function SourceEditor( {
 		mediaType: undefined,
 		mediaValue: undefined,
 	},
+	index,
 	disableMoveUp = false,
 	disableMoveDown = false,
 	disableActions = false,
@@ -83,6 +86,10 @@ export default function SourceEditor( {
 	const { createErrorNotice, removeAllNotices } = useDispatch( noticesStore );
 
 	const [ isLoading, setIsLoading ] = useState( false );
+
+	const instanceId = useInstanceId( SourceEditor );
+	const moveUpDescriptionId = `enable-responsive-image__mover-description-up-${ instanceId }`;
+	const moveDownDescriptionId = `enable-responsive-image__mover-description-down-${ instanceId }`;
 
 	const imageSizeOptions = imageSizes
 		.filter( ( { slug }: { slug: string } ) => {
@@ -202,16 +209,64 @@ export default function SourceEditor( {
 											icon={ chevronUp }
 											size="small"
 											disabled={ disableMoveUp }
+											aria-describedby={ moveUpDescriptionId }
 											onClick={ () => onChangeOrder?.( -1 ) }
+											accessibleWhenDisabled
 										/>
+										{ index !== undefined && (
+											<VisuallyHidden id={ moveUpDescriptionId }>
+												{ disableMoveUp
+													? sprintf(
+															/* translators: %d: Image source number. */
+															__(
+																'Image source %d is at the beginning of the content and can’t be moved up',
+																'enable-responsive-image'
+															),
+															index + 1
+													  )
+													: sprintf(
+															/* translators: 1: Current image source number. 2: New image source number. */
+															__(
+																'Move image source %1$d to position %2$d',
+																'enable-responsive-image'
+															),
+															index + 1,
+															index
+													  ) }
+											</VisuallyHidden>
+										) }
 										<Button
 											className="enable-responsive-image__mover"
 											label={ __( 'Move down', 'enable-responsive-image' ) }
 											icon={ chevronDown }
 											size="small"
 											disabled={ disableMoveDown }
+											aria-describedby={ moveDownDescriptionId }
 											onClick={ () => onChangeOrder?.( 1 ) }
+											accessibleWhenDisabled
 										/>
+										{ index !== undefined && (
+											<VisuallyHidden id={ moveDownDescriptionId }>
+												{ disableMoveDown
+													? sprintf(
+															/* translators: %d: Image source number. */
+															__(
+																'Image source %d is at the end of the content and can’t be moved down',
+																'enable-responsive-image'
+															),
+															index + 1
+													  )
+													: sprintf(
+															/* translators: 1: Current image source number. 2: New image source number. */
+															__(
+																'Move image source %1$d to position %2$d',
+																'enable-responsive-image'
+															),
+															index + 1,
+															index + 2
+													  ) }
+											</VisuallyHidden>
+										) }
 									</>
 								) }
 							</Stack>

--- a/src/source-editor.tsx
+++ b/src/source-editor.tsx
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import type { Ref } from 'react';
+
+/**
  * WordPress dependencies
  */
 import { useState } from '@wordpress/element';
@@ -33,6 +38,8 @@ type Props = {
 	disableMoveUp: boolean;
 	disableMoveDown: boolean;
 	disableActions?: boolean;
+	moveUpRef?: Ref< HTMLButtonElement >;
+	moveDownRef?: Ref< HTMLButtonElement >;
 	onChange: ( source: Source ) => void;
 	onRemove: () => void;
 	onChangeOrder?: ( direction: number ) => void;
@@ -51,6 +58,8 @@ export default function SourceEditor( {
 	disableMoveUp = false,
 	disableMoveDown = false,
 	disableActions = false,
+	moveUpRef,
+	moveDownRef,
 	onChangeOrder,
 	onChange,
 	onRemove,
@@ -204,6 +213,7 @@ export default function SourceEditor( {
 								{ ! ( disableMoveUp && disableMoveDown ) && (
 									<>
 										<Button
+											ref={ moveUpRef }
 											className="enable-responsive-image__mover"
 											label={ __( 'Move up', 'enable-responsive-image' ) }
 											icon={ chevronUp }
@@ -236,6 +246,7 @@ export default function SourceEditor( {
 											</VisuallyHidden>
 										) }
 										<Button
+											ref={ moveDownRef }
 											className="enable-responsive-image__mover"
 											label={ __( 'Move down', 'enable-responsive-image' ) }
 											icon={ chevronDown }

--- a/src/source-list.tsx
+++ b/src/source-list.tsx
@@ -1,6 +1,7 @@
 /**
  * WordPress dependencies
  */
+import { useRef } from '@wordpress/element';
 import { __, sprintf } from '@wordpress/i18n';
 import {
 	Button,
@@ -22,6 +23,9 @@ import { MAX_SOURCES } from './constants';
 export default function ImageList( props: BlockEditProps< BlockAttributes > ) {
 	const { attributes, setAttributes } = props;
 	const { enableResponsiveImageSources: sources } = attributes;
+
+	const moveUpRefs = useRef< ( HTMLButtonElement | null )[] >( [] );
+	const moveDownRefs = useRef< ( HTMLButtonElement | null )[] >( [] );
 
 	function onChange( newSource: Source, index: number ) {
 		const newSources = [ ...sources ];
@@ -47,6 +51,13 @@ export default function ImageList( props: BlockEditProps< BlockAttributes > ) {
 		const movedSource = newSources.splice( index, 1 )[ 0 ];
 		newSources.splice( newIndex, 0, movedSource );
 		setAttributes( { enableResponsiveImageSources: newSources } );
+
+		// Move focus to the mover button at the new position so it follows the
+		// moved source, after the reorder has rendered.
+		window.requestAnimationFrame( () => {
+			const refs = direction < 0 ? moveUpRefs : moveDownRefs;
+			refs.current[ newIndex ]?.focus();
+		} );
 	}
 
 	function onRemoveSource( index: number ) {
@@ -114,6 +125,12 @@ export default function ImageList( props: BlockEditProps< BlockAttributes > ) {
 									index={ index }
 									disableMoveUp={ index === 0 }
 									disableMoveDown={ index === sources.length - 1 }
+									moveUpRef={ ( el ) => {
+										moveUpRefs.current[ index ] = el;
+									} }
+									moveDownRef={ ( el ) => {
+										moveDownRefs.current[ index ] = el;
+									} }
 									source={ source }
 									onChangeOrder={ ( direction ) => onChangeOrder( direction, index ) }
 									onChange={ ( newSource ) => onChange( newSource, index ) }

--- a/src/source-list.tsx
+++ b/src/source-list.tsx
@@ -111,6 +111,7 @@ export default function ImageList( props: BlockEditProps< BlockAttributes > ) {
 								</legend>
 								<SourceEditor
 									{ ...props }
+									index={ index }
 									disableMoveUp={ index === 0 }
 									disableMoveDown={ index === sources.length - 1 }
 									source={ source }

--- a/test/e2e/test.spec.ts
+++ b/test/e2e/test.spec.ts
@@ -108,6 +108,92 @@ test.describe( 'Image Block', () => {
 		expect( sources?.[ 0 ]?.srcset?.includes( firstSourceFilename ) ).toBe( true );
 		expect( sources?.[ 1 ]?.srcset?.includes( secondSourceFilename ) ).toBe( true );
 	} );
+
+	test( 'should move an image source up', async ( { editor, page, mediaUtils } ) => {
+		// Insert Image block with a main image.
+		await editor.insertBlock( { name: 'core/image' } );
+		const imageBlock = editor.canvas.getByRole( 'document', { name: 'Block: Image' } );
+		await expect( imageBlock ).toBeVisible();
+		await mediaUtils.uploadImage(
+			imageBlock.locator( 'data-testid=form-file-upload-input' ),
+			'1000x750.png'
+		);
+
+		// Add three image sources.
+		await editor.openDocumentSettingsSidebar();
+		await page.getByRole( 'tab', { name: 'Settings' } ).click();
+		await mediaUtils.addImageSource( '1000x750.png' );
+		await mediaUtils.addImageSource( '600x450.png' );
+		await mediaUtils.addImageSource( '400x300.png' );
+
+		const panel = page
+			.getByRole( 'region', { name: 'Editor settings' } )
+			.locator( '.enable-responsive-image' );
+
+		// Capture the srcset of each source in its original order.
+		const [ firstSrcset, secondSrcset, thirdSrcset ] = (
+			( await editor.getBlocks() )[ 0 ].attributes.enableResponsiveImageSources as Source[]
+		 ).map( ( source ) => source.srcset );
+		await panel.getByRole( 'button', { name: 'Move up' } ).nth( 1 ).click();
+
+		await expect.poll( editor.getBlocks ).toMatchObject( [
+			{
+				attributes: {
+					enableResponsiveImageSources: [
+						{ srcset: secondSrcset },
+						{ srcset: firstSrcset },
+						{ srcset: thirdSrcset },
+					],
+				},
+			},
+		] );
+
+		// Focus follows the moved source to its new position.
+		await expect( panel.getByRole( 'button', { name: 'Move up' } ).nth( 0 ) ).toBeFocused();
+	} );
+
+	test( 'should move an image source down', async ( { editor, page, mediaUtils } ) => {
+		// Insert Image block with a main image.
+		await editor.insertBlock( { name: 'core/image' } );
+		const imageBlock = editor.canvas.getByRole( 'document', { name: 'Block: Image' } );
+		await expect( imageBlock ).toBeVisible();
+		await mediaUtils.uploadImage(
+			imageBlock.locator( 'data-testid=form-file-upload-input' ),
+			'1000x750.png'
+		);
+
+		// Add three image sources.
+		await editor.openDocumentSettingsSidebar();
+		await page.getByRole( 'tab', { name: 'Settings' } ).click();
+		await mediaUtils.addImageSource( '1000x750.png' );
+		await mediaUtils.addImageSource( '600x450.png' );
+		await mediaUtils.addImageSource( '400x300.png' );
+
+		const panel = page
+			.getByRole( 'region', { name: 'Editor settings' } )
+			.locator( '.enable-responsive-image' );
+		const [ firstSrcset, secondSrcset, thirdSrcset ] = (
+			( await editor.getBlocks() )[ 0 ].attributes.enableResponsiveImageSources as Source[]
+		 ).map( ( source ) => source.srcset );
+
+		// Move the second image source down.
+		await panel.getByRole( 'button', { name: 'Move down' } ).nth( 1 ).click();
+
+		await expect.poll( editor.getBlocks ).toMatchObject( [
+			{
+				attributes: {
+					enableResponsiveImageSources: [
+						{ srcset: firstSrcset },
+						{ srcset: thirdSrcset },
+						{ srcset: secondSrcset },
+					],
+				},
+			},
+		] );
+
+		// Focus follows the moved source to its new position.
+		await expect( panel.getByRole( 'button', { name: 'Move down' } ).nth( 2 ) ).toBeFocused();
+	} );
 } );
 
 class MediaUtils {
@@ -139,6 +225,12 @@ class MediaUtils {
 			.getByRole( 'button', { name: 'Select', exact: true } )
 			.click();
 		return filename;
+	}
+
+	async addImageSource( customFile: string ) {
+		await this.page.getByRole( 'button', { name: 'Add image source' } ).click();
+		await this.page.getByRole( 'button', { name: 'Set image source' } ).click();
+		return this.uploadSource( customFile );
 	}
 
 	async changeMediaQueryType( option: string, index = 0 ) {


### PR DESCRIPTION
Part of #95

## Summary

Improves the accessibility of the image source "Move up" / "Move down" buttons in the Image block sidebar.

- Keeps the `Move up` / `Move down` labels, and adds an `aria-describedby` description announcing which source number moves to which position, or a dedicated message when it is already at the beginning/end.
- After a reorder, moves focus to the mover button now at the moved source's new position. Because the list is keyed by index, focus previously stayed on the index-based DOM position instead of following the moved source.

## Approach

- `SourceEditor` renders a `VisuallyHidden` description per button and forwards refs to the mover buttons.
- `ImageList` keeps refs to each source's buttons and, after `setAttributes`, focuses the target button inside `requestAnimationFrame` so the updated disabled state and description are announced.

## Testing

- Added e2e tests for the up and down cases, asserting both the new source order and the resulting focus.
