### PR TITLE
Move focus after removing an image source

### DIFF
--- a/src/source-editor.tsx
+++ b/src/source-editor.tsx
@@ -38,6 +38,7 @@ type Props = {
 	disableMoveUp: boolean;
 	disableMoveDown: boolean;
 	disableActions?: boolean;
+	toggleRef?: Ref< HTMLButtonElement >;
 	moveUpRef?: Ref< HTMLButtonElement >;
 	moveDownRef?: Ref< HTMLButtonElement >;
 	onChange: ( source: Source ) => void;
@@ -58,6 +59,7 @@ export default function SourceEditor( {
 	disableMoveUp = false,
 	disableMoveDown = false,
 	disableActions = false,
+	toggleRef,
 	moveUpRef,
 	moveDownRef,
 	onChangeOrder,
@@ -186,6 +188,7 @@ export default function SourceEditor( {
 					render={ ( { open } ) => (
 						<div className="enable-responsive-image__container">
 							<Button
+								ref={ toggleRef }
 								className={
 									! id ? 'enable-responsive-image__toggle' : 'enable-responsive-image__preview'
 								}

--- a/src/source-list.tsx
+++ b/src/source-list.tsx
@@ -24,8 +24,10 @@ export default function ImageList( props: BlockEditProps< BlockAttributes > ) {
 	const { attributes, setAttributes } = props;
 	const { enableResponsiveImageSources: sources } = attributes;
 
+	const toggleRefs = useRef< ( HTMLButtonElement | null )[] >( [] );
 	const moveUpRefs = useRef< ( HTMLButtonElement | null )[] >( [] );
 	const moveDownRefs = useRef< ( HTMLButtonElement | null )[] >( [] );
+	const addSourceRef = useRef< HTMLButtonElement | null >( null );
 
 	function onChange( newSource: Source, index: number ) {
 		const newSources = [ ...sources ];
@@ -60,10 +62,24 @@ export default function ImageList( props: BlockEditProps< BlockAttributes > ) {
 		} );
 	}
 
-	function onRemoveSource( index: number ) {
+	function onRemoveSource( index: number, shouldFocus = false ) {
 		const newSources = [ ...sources ];
 		newSources.splice( index, 1 );
 		setAttributes( { enableResponsiveImageSources: newSources } );
+
+		if ( ! shouldFocus ) {
+			return;
+		}
+
+		// Move focus to the previous source, falling back to the next one, or to
+		// the add button when no source is left, after the removal has rendered.
+		window.requestAnimationFrame( () => {
+			if ( newSources.length === 0 ) {
+				addSourceRef.current?.focus();
+				return;
+			}
+			toggleRefs.current[ index > 0 ? index - 1 : 0 ]?.focus();
+		} );
 	}
 	const dropdownMenuProps = ! useViewportMatch( 'medium', '<' )
 		? {
@@ -125,6 +141,9 @@ export default function ImageList( props: BlockEditProps< BlockAttributes > ) {
 									index={ index }
 									disableMoveUp={ index === 0 }
 									disableMoveDown={ index === sources.length - 1 }
+									toggleRef={ ( el ) => {
+										toggleRefs.current[ index ] = el;
+									} }
 									moveUpRef={ ( el ) => {
 										moveUpRefs.current[ index ] = el;
 									} }
@@ -134,13 +153,14 @@ export default function ImageList( props: BlockEditProps< BlockAttributes > ) {
 									source={ source }
 									onChangeOrder={ ( direction ) => onChangeOrder( direction, index ) }
 									onChange={ ( newSource ) => onChange( newSource, index ) }
-									onRemove={ () => onRemoveSource( index ) }
+									onRemove={ () => onRemoveSource( index, true ) }
 								/>
 								{ index < sources.length - 1 && <hr /> }
 							</fieldset>
 						</ToolsPanelItem>
 					) ) }
 				<Button
+					ref={ addSourceRef }
 					variant="primary"
 					className="enable-responsive-image__add-source"
 					disabled={ sources.length >= MAX_SOURCES }

--- a/test/e2e/test.spec.ts
+++ b/test/e2e/test.spec.ts
@@ -194,6 +194,137 @@ test.describe( 'Image Block', () => {
 		// Focus follows the moved source to its new position.
 		await expect( panel.getByRole( 'button', { name: 'Move down' } ).nth( 2 ) ).toBeFocused();
 	} );
+
+	test( 'should move focus to the add button when the last image source is removed', async ( {
+		editor,
+		page,
+		mediaUtils,
+	} ) => {
+		// Insert Image block with a main image.
+		await editor.insertBlock( { name: 'core/image' } );
+		const imageBlock = editor.canvas.getByRole( 'document', { name: 'Block: Image' } );
+		await expect( imageBlock ).toBeVisible();
+		await mediaUtils.uploadImage(
+			imageBlock.locator( 'data-testid=form-file-upload-input' ),
+			'1000x750.png'
+		);
+
+		// Add a single image source.
+		await editor.openDocumentSettingsSidebar();
+		await page.getByRole( 'tab', { name: 'Settings' } ).click();
+		await mediaUtils.addImageSource( '1000x750.png' );
+
+		const panel = page
+			.getByRole( 'region', { name: 'Editor settings' } )
+			.locator( '.enable-responsive-image' );
+
+		await panel.getByRole( 'button', { name: 'Remove', exact: true } ).click();
+
+		await expect.poll( editor.getBlocks ).toMatchObject( [
+			{
+				attributes: {
+					enableResponsiveImageSources: [],
+				},
+			},
+		] );
+
+		// Focus moves to the add button because no image source is left.
+		await expect( page.getByRole( 'button', { name: 'Add image source' } ) ).toBeFocused();
+	} );
+
+	test( 'should move focus to the previous image source when a source is removed', async ( {
+		editor,
+		page,
+		mediaUtils,
+	} ) => {
+		// Insert Image block with a main image.
+		await editor.insertBlock( { name: 'core/image' } );
+		const imageBlock = editor.canvas.getByRole( 'document', { name: 'Block: Image' } );
+		await expect( imageBlock ).toBeVisible();
+		await mediaUtils.uploadImage(
+			imageBlock.locator( 'data-testid=form-file-upload-input' ),
+			'1000x750.png'
+		);
+
+		// Add three image sources.
+		await editor.openDocumentSettingsSidebar();
+		await page.getByRole( 'tab', { name: 'Settings' } ).click();
+		await mediaUtils.addImageSource( '1000x750.png' );
+		await mediaUtils.addImageSource( '600x450.png' );
+		await mediaUtils.addImageSource( '400x300.png' );
+
+		const panel = page
+			.getByRole( 'region', { name: 'Editor settings' } )
+			.locator( '.enable-responsive-image' );
+
+		// Capture the srcset of each source in its original order.
+		const [ firstSrcset, , thirdSrcset ] = (
+			( await editor.getBlocks() )[ 0 ].attributes.enableResponsiveImageSources as Source[]
+		 ).map( ( source ) => source.srcset );
+
+		// Remove the second image source.
+		await panel.getByRole( 'button', { name: 'Remove', exact: true } ).nth( 1 ).click();
+
+		await expect.poll( editor.getBlocks ).toMatchObject( [
+			{
+				attributes: {
+					enableResponsiveImageSources: [ { srcset: firstSrcset }, { srcset: thirdSrcset } ],
+				},
+			},
+		] );
+
+		// Focus moves to the previous image source.
+		await expect(
+			panel.getByRole( 'button', { name: 'Replace image source', exact: true } ).nth( 0 )
+		).toBeFocused();
+	} );
+
+	test( 'should move focus to the next image source when the first source is removed', async ( {
+		editor,
+		page,
+		mediaUtils,
+	} ) => {
+		// Insert Image block with a main image.
+		await editor.insertBlock( { name: 'core/image' } );
+		const imageBlock = editor.canvas.getByRole( 'document', { name: 'Block: Image' } );
+		await expect( imageBlock ).toBeVisible();
+		await mediaUtils.uploadImage(
+			imageBlock.locator( 'data-testid=form-file-upload-input' ),
+			'1000x750.png'
+		);
+
+		// Add three image sources.
+		await editor.openDocumentSettingsSidebar();
+		await page.getByRole( 'tab', { name: 'Settings' } ).click();
+		await mediaUtils.addImageSource( '1000x750.png' );
+		await mediaUtils.addImageSource( '600x450.png' );
+		await mediaUtils.addImageSource( '400x300.png' );
+
+		const panel = page
+			.getByRole( 'region', { name: 'Editor settings' } )
+			.locator( '.enable-responsive-image' );
+
+		// Capture the srcset of each source in its original order.
+		const [ , secondSrcset, thirdSrcset ] = (
+			( await editor.getBlocks() )[ 0 ].attributes.enableResponsiveImageSources as Source[]
+		 ).map( ( source ) => source.srcset );
+
+		// Remove the first image source.
+		await panel.getByRole( 'button', { name: 'Remove', exact: true } ).nth( 0 ).click();
+
+		await expect.poll( editor.getBlocks ).toMatchObject( [
+			{
+				attributes: {
+					enableResponsiveImageSources: [ { srcset: secondSrcset }, { srcset: thirdSrcset } ],
+				},
+			},
+		] );
+
+		// Focus moves to the next image source, which is now the first one.
+		await expect(
+			panel.getByRole( 'button', { name: 'Replace image source', exact: true } ).nth( 0 )
+		).toBeFocused();
+	} );
 } );
 
 class MediaUtils {


### PR DESCRIPTION
Fixes #95

Clicking the Remove button destroyed the focused element, dropping focus to the document body and leaving keyboard and screen reader users without a position in the panel. Focus now moves to the previous source's image toggle button, falling back to the next source when the first one is removed, or to the Add image source button when no source is left.

The focus handling is limited to the Remove button, so removing a source from the ToolsPanel dropdown menu keeps focus within the menu.